### PR TITLE
fix: add closed status to Github query to close related Jiras

### DIFF
--- a/src/handleUnprocessedJiraIssues.js
+++ b/src/handleUnprocessedJiraIssues.js
@@ -9,7 +9,7 @@ import { errorCollector } from './index.js';
 
 // Additional check only for unprocessed Jira issues
 // Find their GH issue and see if Jira issue needs to be transitioned to match GH state
-export async function handleUnprocessedJiraIssues(unprocessedJiraIssues) {
+export async function handleUnprocessedJiraIssues(unprocessedJiraIssues, repo) {
   console.log(
     `Found ${unprocessedJiraIssues.length} Jira issues that weren't updated. Checking their GitHub status...`
   );

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -269,7 +269,7 @@ export const GET_ALL_REPO_ISSUES = `
     $repo: String!
     $numIssuesToFetch: Int = 100
     $issuesCursor: String
-    $issueStates: [IssueState!] = [OPEN]
+    $issueStates: [IssueState!] = [OPEN, CLOSED]
     $numLabelsPerIssue: Int = 10
     $numAssigneesPerIssue: Int = 10
     $numCommentsPerIssue: Int = 20

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,8 @@ async function syncIssues(repo, since) {
     );
 
     if (unprocessedJiraIssues.length > 0) {
-      // await handleUnprocessedJiraIssues(unprocessedJiraIssues);
+      // Uncomment to process all open Jira issues regardless of GitHub status
+      // await handleUnprocessedJiraIssues(unprocessedJiraIssues, repo);
     }
 
     // Log any collected errors at the end


### PR DESCRIPTION
Closes #9 

This PR:
- Updates the Github query to fetch both open AND closed issues that have been updated
- Adds logic to check if the updated Github issue is closed, and if so close the related Jira issue
- Passes the `repo` variable through to `handleUnprocessedJiraIssues` function where it was being used but undefined.
  - This function remains commented out, but added a note to uncomment this in the case that all Jira issues need to be processed (such as with this cleanup, closing out ~600 stale Jira issues)