### PR TITLE
fix: format Jira comments, validate CLI arg, cleanup error logging

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -579,15 +579,13 @@ export async function getRepoIssues(repo, ghOwner = 'patternfly', since) {
 
       // Validate response structure
       if (!response?.repository?.issues) {
-        debugger;
         throw new Error('Invalid response structure from GitHub API');
       }
 
       const { nodes, pageInfo } = response.repository.issues;
 
-      // Handle empty repository or no issues
+      // Handle empty repository or no matching issues
       if (!nodes || nodes.length === 0) {
-        console.log(`No issues found in repository ${ghOwner}/${repo}`);
         break;
       }
 
@@ -688,7 +686,7 @@ export async function syncCommentsToJira(jiraIssueKey, githubComments) {
       // Format the comment body with GitHub metadata
       let commentBody =
         `Comment Author: ${comment.author.login}\n` +
-        `\n----\n\n${comment.body}\n\n----\n\n` +
+        `\n----\n\n${convertMarkdownToJira(comment.body)}\n\n----\n\n` +
         `Comment Created: ${comment.createdAt}\n` +
         `Comment URL: ${comment.url}\n`;
 
@@ -714,20 +712,6 @@ export async function syncCommentsToJira(jiraIssueKey, githubComments) {
         ` - Added comment from ${comment.author.login} to Jira issue ${jiraIssueKey}`
       );
     }
-
-    // Remove any comments that no longer exist in GitHub
-    // Ignore - we add comments directly in Jira intentionally
-    /*
-    for (const [_, comment] of existingComments) {
-      await delay();
-      await jiraClient.delete(
-        `/rest/api/2/issue/${jiraIssueKey}/comment/${comment.id}`
-      );
-      console.log(
-        ` - Removed outdated comment from Jira issue ${jiraIssueKey}`
-      );
-    }
-    */
 
     if (addedCommentCount > 0) {
       console.log(` - Completed syncing ${addedCommentCount} new comments.`);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,14 @@ import { handleUnprocessedJiraIssues } from './handleUnprocessedJiraIssues.js';
 
 export let jiraIssues = [];
 
+const isValidISOString = (str) => {
+  if (typeof str !== 'string') {
+    return false;
+  }
+  // Matches ISO 8601 format: YYYY-MM-DDTHH:MM:SS with optional milliseconds (.XXX) and timezone (Z or ±HH:MM)
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:?\d{2})?$/i.test(str);
+};
+
 // Parse command line arguments
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -15,24 +23,34 @@ function parseArgs() {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--since' && i + 1 < args.length) {
       const sinceValue = args[i + 1];
-      
-      // Check if the value is in MM-DD-YYYY format
-      const mmddPattern = /^(\d{1,2})-(\d{1,2})-(\d{4})$/;
-      const match = sinceValue.match(mmddPattern);
-      
-      if (match) {
-        // Convert MM-DD-YYYY to ISO string
-        const month = parseInt(match[1]) - 1; // Month is 0-indexed in Date constructor
-        const day = parseInt(match[2]);
-        const year = parseInt(match[3]);
-        const date = new Date(year, month, day);
-        options.since = date.toISOString();
-      } else {
-        // Assume it's already in ISO format or another valid format
+
+      if (isValidISOString(sinceValue)) {
         options.since = sinceValue;
+      } else {
+        // Check if the value is in MM-DD-YYYY format
+        const mmddPattern = /^(\d{1,2})-(\d{1,2})-(\d{4})$/;
+        const match = sinceValue.match(mmddPattern);
+        
+        if (match) {
+          // Convert MM-DD-YYYY to ISO string
+          const month = parseInt(match[1]) - 1; // Month is 0-indexed in Date constructor
+          const day = parseInt(match[2]);
+          const year = parseInt(match[3]);
+          const date = new Date(year, month, day);
+          options.since = date.toISOString();
+        } else {
+          // Default fallback: 7 days ago
+          console.error(`** ERROR: Invalid date format: ${sinceValue}\nDefaulting to 7 days ago`);
+          options.since = (() => {
+            const date = new Date();
+            date.setDate(date.getDate() - 7);
+            return date.toISOString();
+          })();
+        }
       }
       
-      i++; // Skip the next argument since we consumed it
+      // Skip the next argument since we consumed it
+      i++;
     }
   }
   
@@ -61,14 +79,13 @@ class ErrorCollector {
   logErrors() {
     if (!this.hasErrors()) return;
 
-    console.error('\n=== Sync Errors ===');
     this.errors.forEach(({ context, message, response }) => {
-      console.error(`${context}: ${message}`);
+      console.error(`  ${context}: ${message}`);
       if (response) {
         console.error(`  Response: ${JSON.stringify(response)}`);
       }
+      console.error('  ==============================================');
     });
-    console.error('==================\n');
   }
 
   clear() {
@@ -79,62 +96,52 @@ class ErrorCollector {
 // Create global error collector instance
 export const errorCollector = new ErrorCollector();
 
-async function syncIssues(repo, owner, since) {
-  /* DEBUG
-    debugger;
-    return;
-  */
+const fetchJiraIssues = async (owner, repo, since) => {
+  console.log(' - fetching Jira...');
+  const response = await jiraClient.get('/rest/api/2/search', {
+    params: {
+      jql: `project = PF AND component = "${repo}" AND status not in (Closed, Resolved) ORDER BY key ASC`,
+      maxResults: 1000,
+      fields: 'key,id,description,status, issuetype',
+    },
+  });
+  const jiraIssues = response?.data?.issues || [];
+  console.log(`    --> Found ${jiraIssues.length} open Jira issues for Jira component ${ repo }`); 
+  return jiraIssues;
+};
+
+const fetchGitHubIssues = async (owner, repo, since) => {
+  console.log(' - fetching GitHub...');
+  const githubApiResponse = await getRepoIssues(repo, owner, since);
+  // Sort by number to ensure consistent order, enables easier debugging
+  const githubIssues = githubApiResponse.repository.issues.nodes.sort(
+    (a, b) => a.number - b.number
+  );
+
+  console.log(`    --> Found ${githubIssues.length} updated GitHub issue${githubIssues.length === 1 ? '' : 's'} in ${ owner }/${ repo }\n`);
+  return githubIssues;
+};
+
+async function syncIssues(owner, repo, since) {
+  console.log(`\n=== START Syncing issues for repo ${ owner }/${ repo } updated since ${since} ===\n`);
   try {
-    jiraIssues = [];
     // Clear any previous errors
     // errorCollector.clear();
-    // Fetch all Jira issues for the specific repo/component
-    console.log('fetching Jira');
-    const response = await jiraClient.get('/rest/api/2/search', {
-      params: {
-        jql: `project = PF AND component = "${repo}" AND status not in (Closed, Resolved) ORDER BY key ASC`,
-        maxResults: 1000,
-        fields: 'key,id,description,status, issuetype',
-      },
-    });
-    // Assign the issues to our exported variable
-    jiraIssues = response.data.issues;
-    // Get GitHub issues from GraphQL response
-    console.log('fetching GH');
-    const githubApiResponse = await getRepoIssues(repo, owner, since);
-    // Sort by number to ensure consistent order, enables easier debugging
-    const githubIssues = githubApiResponse.repository.issues.nodes.sort(
-      (a, b) => a.number - b.number
-    );
 
-    console.log(
-      `** Found ${jiraIssues.length} open Jira issues for repo ${
-        repo
-      } and ${githubIssues.length} open GitHub issues **\n`
-    );
+    // Fetch all open Jira issues for the specific repo/component, save to exported variable
+    jiraIssues = await fetchJiraIssues(owner, repo, since);
+
+    // Fetch all updated GitHub issues from GraphQL response
+    const githubIssues = await fetchGitHubIssues(owner, repo, since);
 
     // Keep track of which Jira issues we've processed
     const processedJiraIssues = new Set();
 
     // Process GitHub issues
     for (const [index, issue] of githubIssues.entries()) {
-      // Skip if the issue is a pull request (GraphQL doesn't return pull requests)
-      if (issue.pull_request) {
-        console.log(
-          `(${index + 1}/${githubIssues.length}) Skipping pull request #${
-            issue.number
-          }`
-        );
-        continue;
-      }
-
-      // Skip if the issue is an Initiative
-      if (issue?.issueType?.name === 'Initiative') {
-        console.log(
-          `(${index + 1}/${githubIssues.length}) Skipping Initiative #${
-            issue.number
-          }\n`
-        );
+      // Skip if the issue is a pull request (GraphQL doesn't return pull requests) or an Initiative
+      if (issue.pull_request || issue?.issueType?.name === 'Initiative') {
+        console.log(`(${index + 1}/${githubIssues.length}) Skipping ${issue.pull_request ? 'pull request' : 'Initiative'} #${ issue.number}`);
         continue;
       }
 
@@ -143,19 +150,11 @@ async function syncIssues(repo, owner, since) {
 
       if (!jiraIssue) {
         // Create new Jira issue
-        console.log(
-          `(${index + 1}/${
-            githubIssues.length
-          }) Creating new Jira issue for GitHub issue #${issue.number}`
-        );
+        console.log(`(${index + 1}/${ githubIssues.length }) Creating new Jira issue for GitHub issue #${issue.number}`);
         await createJiraIssue(issue);
       } else {
         // Update existing Jira issue
-        console.log(
-          `(${index + 1}/${
-            githubIssues.length
-          }) Updating existing Jira issue: ${jiraIssue.key}...`
-        );
+        console.log(`(${index + 1}/${githubIssues.length}) Updating existing Jira issue: ${jiraIssue.key}`);
         await updateJiraIssue(jiraIssue, issue);
         processedJiraIssues.add(jiraIssue.key);
       }
@@ -167,20 +166,20 @@ async function syncIssues(repo, owner, since) {
       (issue) => !processedJiraIssues.has(issue.key)
     );
 
-    if (unprocessedJiraIssues.length > 0) {
-      // Uncomment to process all open Jira issues regardless of GitHub status
+    // Uncomment to process all open Jira issues regardless of GitHub status
+    // if (unprocessedJiraIssues.length > 0) {
       // await handleUnprocessedJiraIssues(unprocessedJiraIssues, repo);
-    }
-
-    // Log any collected errors at the end
-    console.log(`\n=== ${repo.toUpperCase()} ERRORS ===\n`);
-    errorCollector.logErrors();
-    console.log(`\n=== END ${repo.toUpperCase()} ERRORS ===\n`);
+    // }
   } catch (error) {
     errorCollector.addError('INDEX: Sync process', error);
-    console.log(`\n=== ${repo.toUpperCase()} ERRORS ===\n`);
-    errorCollector.logErrors();
-    console.log(`\n=== END ${repo.toUpperCase()} ERRORS ===\n`);
+  } finally {
+    if (errorCollector.hasErrors()) {
+      // Log any collected errors at the end
+      console.log(`\n=== ${repo.toUpperCase()} ERRORS ===\n`);
+      errorCollector.logErrors();
+      console.log(`\n=== END ${repo.toUpperCase()} ERRORS ===\n`);
+      errorCollector.clear();
+    }
   }
 }
 
@@ -190,11 +189,11 @@ const since = options.since || (() => {
   const date = new Date();
   date.setDate(date.getDate() - 7);
   return date.toISOString();
-})(); // Default fallback: 7 days ago
+})();
 
 console.log(`Syncing issues since: ${since}`);
 
 // If syncing all, loop through availableComponents
 for (const {name, owner} of availableComponents) {
-  await syncIssues(name, owner, since);
+  await syncIssues(owner, name, since);
 }


### PR DESCRIPTION
Closes #15 

This PR:
- Formats comments markdown from Github for Jira the same way we already do for the issue description field.
- Adds validation for --since CLI argument with fallback default of 7 days prior
- Cleans up errors by clearing errors after each repo rather than carrying all errors forward
- General cleanup, removal of unused code