### PR TITLE
fix: process all recently-updates jiras

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -532,6 +532,7 @@ export const GET_ISSUE_DETAILS = `
         number
         title
         url
+        body
         bodyText
         state
         updatedAt


### PR DESCRIPTION
Closes #22 

This PR adds functionality to loop through all recently-updated Jira issues, to catch updates made in Jira where a related Github issue has not been changed recently.  This essentially mirrors the existing Github sync which looks at all issues updated in the prior 7 days, but for Jira issues.