### PR TITLE
chore: add pf-ai-coding repo to sync

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -235,6 +235,10 @@ export const availableComponents = [
     owner: 'patternfly',
   },
   {
+    name: 'patternfly-ai-coding',
+    owner: 'patternfly',
+  },
+  {
     name: 'patternfly-cli',
     owner: 'patternfly',
   },


### PR DESCRIPTION
Closes #24 

This PR adds the patternfly-ai-coding repo to the sync.  Note this repo will be renamed shortly and another follow-up change will be required.