### PR TITLE
fix: create GitHub issues for old Jira issues updated without Upstream URL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ async function syncIssues(owner, repo, since, direction = 'both') {
       );
       let jiraIssuesWithoutUpstream = [];
       if (recentlyUpdatedJiraIssues.length > 0) {
-        jiraIssuesWithoutUpstream = await syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, repo, owner) || [];
+        jiraIssuesWithoutUpstream = await syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, repo, owner);
       } else {
         console.log(`  No recently-updated Jira issues to sync.`);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ const fetchJiraIssues = async (owner, repo, since) => {
   const jiraDate = new Date(since).toISOString().replace('T', ' ').substring(0, 16);
   const jiraIssues = await paginatedJiraSearch(
     `project = PF AND component = "${repo}" AND status not in (Closed, Resolved) AND updatedDate >= "${jiraDate}" ORDER BY key ASC`,
-    'key,id,description,status,assignee,issuetype,updated,summary,components'
+    'key,id,description,status,resolution,assignee,issuetype,updated,summary,components,reporter'
   );
   console.log(`    --> Found ${jiraIssues.length} open Jira issues updated since ${since} for Jira component ${ repo }`);
   return jiraIssues;
@@ -211,8 +211,9 @@ async function syncIssues(owner, repo, since, direction = 'both') {
       const recentlyUpdatedJiraIssues = jiraIssues.filter(
         (issue) => !processedJiraIssues.has(issue.key)
       );
+      let jiraIssuesWithoutUpstream = [];
       if (recentlyUpdatedJiraIssues.length > 0) {
-        await syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, repo, owner);
+        jiraIssuesWithoutUpstream = await syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, repo, owner) || [];
       } else {
         console.log(`  No recently-updated Jira issues to sync.`);
       }
@@ -227,8 +228,16 @@ async function syncIssues(owner, repo, since, direction = 'both') {
       // Fetch manually created Jira issues for this component and create GitHub issues
       console.log(`\n= Jira → GitHub sync: manually created Jira issues since ${since} =\n`);
       const manualJiraIssues = await fetchManuallyCreatedJiraIssues(owner, repo, since);
-      if (manualJiraIssues.length > 0) {
-        await createGitHubIssuesForManualJira(manualJiraIssues);
+      // Combine manually-created issues with recently-updated issues that have no upstream URL
+      // Deduplicate by Jira key to avoid double-processing
+      const manualKeys = new Set(manualJiraIssues.map(i => i.key));
+      const additionalIssues = jiraIssuesWithoutUpstream.filter(i => !manualKeys.has(i.key));
+      const allManualJiraIssues = [...manualJiraIssues, ...additionalIssues];
+      if (additionalIssues.length > 0) {
+        console.log(`  Found ${additionalIssues.length} recently-updated Jira issue(s) without Upstream URL — will create GitHub issues`);
+      }
+      if (allManualJiraIssues.length > 0) {
+        await createGitHubIssuesForManualJira(allManualJiraIssues);
       }
     }
   } catch (error) {

--- a/src/syncJiraToGitHub.js
+++ b/src/syncJiraToGitHub.js
@@ -752,13 +752,13 @@ function buildBatchedIssueDetailsQuery(issueRequests) {
 // corresponding GitHub issues were NOT fetched in the GitHub-driven loop
 // (e.g., the GitHub issue wasn't updated recently enough to appear in the fetch).
 export async function syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, repo, owner) {
+  // Collect Jira issues that have no upstream URL — these need GitHub issues created
+  const issuesWithoutUpstream = [];
+
   try {
     console.log(
       `  Found ${recentlyUpdatedJiraIssues.length} recently-updated Jira issue(s) not already processed. Syncing to GitHub...`
     );
-
-    // Collect Jira issues that have no upstream URL — these need GitHub issues created
-    const issuesWithoutUpstream = [];
 
     // Phase 1: Collect all GitHub issue URLs and batch-fetch them
     const issueRequests = [];
@@ -884,7 +884,7 @@ export async function syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, r
       'SYNCJIRATOGITHUB: Error processing recently-updated Jira issues',
       error
     );
-    return [];
+    return issuesWithoutUpstream;
   }
 }
 

--- a/src/syncJiraToGitHub.js
+++ b/src/syncJiraToGitHub.js
@@ -757,13 +757,19 @@ export async function syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, r
       `  Found ${recentlyUpdatedJiraIssues.length} recently-updated Jira issue(s) not already processed. Syncing to GitHub...`
     );
 
+    // Collect Jira issues that have no upstream URL — these need GitHub issues created
+    const issuesWithoutUpstream = [];
+
     // Phase 1: Collect all GitHub issue URLs and batch-fetch them
     const issueRequests = [];
     const jiraIssuesByAlias = new Map();
 
     for (const jiraIssue of recentlyUpdatedJiraIssues) {
       const githubUrl = extractUpstreamUrl(jiraIssue.fields.description);
-      if (!githubUrl) continue;
+      if (!githubUrl) {
+        issuesWithoutUpstream.push(jiraIssue);
+        continue;
+      }
 
       const parsed = parseGitHubUrl(githubUrl);
       if (!parsed) {
@@ -783,7 +789,7 @@ export async function syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, r
 
     if (issueRequests.length === 0) {
       console.log(`  No Jira issues with GitHub links to sync.`);
-      return;
+      return issuesWithoutUpstream;
     }
 
     // Batch fetch in groups of 20 to stay within GraphQL complexity limits
@@ -871,11 +877,14 @@ export async function syncUpdatedJiraIssuesToGitHub(recentlyUpdatedJiraIssues, r
         );
       }
     }
+
+    return issuesWithoutUpstream;
   } catch (error) {
     errorCollector.addError(
       'SYNCJIRATOGITHUB: Error processing recently-updated Jira issues',
       error
     );
+    return [];
   }
 }
 

--- a/tests/sync-edge-cases.test.mjs
+++ b/tests/sync-edge-cases.test.mjs
@@ -569,10 +569,22 @@ console.log('\n=== Old Jira issues without Upstream URL get GitHub issues create
     'syncUpdatedJiraIssuesToGitHub collects issues without upstream URL');
   assert(syncSrc.includes('return issuesWithoutUpstream'),
     'syncUpdatedJiraIssuesToGitHub returns issuesWithoutUpstream');
+
+  // Verify issuesWithoutUpstream is declared outside the try block so catch can access it
+  const declIdx = syncSrc.indexOf('const issuesWithoutUpstream = []');
+  const tryIdx = syncSrc.indexOf('try {', declIdx > -1 ? declIdx : 0);
+  assert(declIdx > -1 && tryIdx > -1 && declIdx < tryIdx,
+    'issuesWithoutUpstream is declared before the try block');
+
+  // Verify catch block returns issuesWithoutUpstream (not []) to preserve partial results
+  const catchBlock = syncSrc.match(/catch \(error\) \{[\s\S]*?SYNCJIRATOGITHUB: Error processing recently-updated[\s\S]*?return (.*?);/);
+  assert(catchBlock, 'catch block has a return statement');
+  assertEqual(catchBlock[1], 'issuesWithoutUpstream',
+    'catch block returns issuesWithoutUpstream (preserves partial results on error)');
 }
 
 {
-  // Verify index.js captures the return value and merges with manual issues
+  // Verify index.js captures the return value, merges with manual issues, and fetches needed fields
   const indexSrc = readFileSync(join(__dirname, '../src/index.js'), 'utf-8');
 
   assert(indexSrc.includes('jiraIssuesWithoutUpstream = await syncUpdatedJiraIssuesToGitHub'),
@@ -581,11 +593,7 @@ console.log('\n=== Old Jira issues without Upstream URL get GitHub issues create
     'index.js deduplicates by Jira key');
   assert(indexSrc.includes('allManualJiraIssues'),
     'index.js combines manual and upstream-less issues');
-}
 
-{
-  // Verify fetchJiraIssues fetches resolution and reporter fields
-  const indexSrc = readFileSync(join(__dirname, '../src/index.js'), 'utf-8');
   const fetchJiraMatch = indexSrc.match(/paginatedJiraSearch\(\s*`project = PF AND component.*?status not in.*?`,\s*'([^']*)'/s);
   assert(fetchJiraMatch, 'found fetchJiraIssues paginatedJiraSearch call');
   assert(fetchJiraMatch[1].includes('resolution'), 'fetchJiraIssues fields include resolution');

--- a/tests/sync-edge-cases.test.mjs
+++ b/tests/sync-edge-cases.test.mjs
@@ -555,6 +555,66 @@ console.log('\n=== Paginated Jira search ===');
   assertEqual(rawCalls, null, 'no raw jiraClient.get search/jql calls remain in index.js');
 }
 
+// ─── Old Jira issues without Upstream URL get GitHub issues created ──────────
+
+console.log('\n=== Old Jira issues without Upstream URL get GitHub issues created ===');
+
+{
+  // Verify syncUpdatedJiraIssuesToGitHub collects issues without upstream URL
+  const syncSrc = readFileSync(join(__dirname, '../src/syncJiraToGitHub.js'), 'utf-8');
+
+  assert(syncSrc.includes('const issuesWithoutUpstream = []'),
+    'syncUpdatedJiraIssuesToGitHub declares issuesWithoutUpstream array');
+  assert(syncSrc.includes('issuesWithoutUpstream.push(jiraIssue)'),
+    'syncUpdatedJiraIssuesToGitHub collects issues without upstream URL');
+  assert(syncSrc.includes('return issuesWithoutUpstream'),
+    'syncUpdatedJiraIssuesToGitHub returns issuesWithoutUpstream');
+}
+
+{
+  // Verify index.js captures the return value and merges with manual issues
+  const indexSrc = readFileSync(join(__dirname, '../src/index.js'), 'utf-8');
+
+  assert(indexSrc.includes('jiraIssuesWithoutUpstream = await syncUpdatedJiraIssuesToGitHub'),
+    'index.js captures return value of syncUpdatedJiraIssuesToGitHub');
+  assert(indexSrc.includes("manualKeys"),
+    'index.js deduplicates by Jira key');
+  assert(indexSrc.includes('allManualJiraIssues'),
+    'index.js combines manual and upstream-less issues');
+}
+
+{
+  // Verify fetchJiraIssues fetches resolution and reporter fields
+  const indexSrc = readFileSync(join(__dirname, '../src/index.js'), 'utf-8');
+  const fetchJiraMatch = indexSrc.match(/paginatedJiraSearch\(\s*`project = PF AND component.*?status not in.*?`,\s*'([^']*)'/s);
+  assert(fetchJiraMatch, 'found fetchJiraIssues paginatedJiraSearch call');
+  assert(fetchJiraMatch[1].includes('resolution'), 'fetchJiraIssues fields include resolution');
+  assert(fetchJiraMatch[1].includes('reporter'), 'fetchJiraIssues fields include reporter');
+}
+
+{
+  // Test deduplication logic: issues appearing in both lists should not be doubled
+  const manualJiraIssues = [
+    { key: 'PF-100', fields: { summary: 'Issue 100' } },
+    { key: 'PF-101', fields: { summary: 'Issue 101' } },
+  ];
+  const jiraIssuesWithoutUpstream = [
+    { key: 'PF-101', fields: { summary: 'Issue 101 (from updated)' } },
+    { key: 'PF-102', fields: { summary: 'Issue 102' } },
+  ];
+
+  const manualKeys = new Set(manualJiraIssues.map(i => i.key));
+  const additionalIssues = jiraIssuesWithoutUpstream.filter(i => !manualKeys.has(i.key));
+  const allManualJiraIssues = [...manualJiraIssues, ...additionalIssues];
+
+  assertEqual(allManualJiraIssues.length, 3, 'deduplication: 3 unique issues (not 4)');
+  assertEqual(additionalIssues.length, 1, 'deduplication: only PF-102 is additional');
+  assertEqual(additionalIssues[0].key, 'PF-102', 'deduplication: additional issue is PF-102');
+  // Manual issues take priority (they have more fields like reporter, resolution)
+  const pf101 = allManualJiraIssues.find(i => i.key === 'PF-101');
+  assertEqual(pf101.fields.summary, 'Issue 101', 'deduplication: manual version of PF-101 takes priority');
+}
+
 // ─── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);


### PR DESCRIPTION
Closes #37 

## Summary
- When an old Jira issue (created before the `since` window) was recently updated and had no Upstream URL, it was silently skipped by both `syncUpdatedJiraIssuesToGitHub` (skips issues without GitHub links) and `createGitHubIssuesForManualJira` (only finds issues created within the `since` window)
- `syncUpdatedJiraIssuesToGitHub` now collects these issues and returns them to the caller, which merges them (deduplicated by Jira key) with manually-created issues for GitHub issue creation
- Added `resolution` and `reporter` fields to `fetchJiraIssues` so the creation function has all needed data

## Test plan
- [x] All 102 tests pass (`npm test`), including 13 new tests
- [ ] Run sync against a repo with an old Jira issue that has no Upstream URL and was recently updated — verify it creates a GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)