### PR TITLE
fix: retry Jira update without assignee when user is unassignable

### DIFF
--- a/src/updateJiraIssue.js
+++ b/src/updateJiraIssue.js
@@ -301,10 +301,12 @@ export async function updateJiraIssue(jiraIssue, githubIssue) {
             throw editError;
           }
         }
-        syncSummary.githubToJira = true;
-        console.log(
-          `  ✓ Synced from GitHub → Jira: ${changes.join(', ')} (GitHub updated ${githubIssue.updatedAt || 'unknown'})`
-        );
+        if (changes.length > 0) {
+          syncSummary.githubToJira = true;
+          console.log(
+            `  ✓ Synced from GitHub → Jira: ${changes.join(', ')} (GitHub updated ${githubIssue.updatedAt || 'unknown'})`
+          );
+        }
       }
 
       // Sync comments

--- a/src/updateJiraIssue.js
+++ b/src/updateJiraIssue.js
@@ -279,7 +279,28 @@ export async function updateJiraIssue(jiraIssue, githubIssue) {
       if (assigneeChanged) changes.push('assignee');
 
       if (changes.length > 0) {
-        await editJiraIssue(jiraIssue.key, jiraIssueData);
+        try {
+          await editJiraIssue(jiraIssue.key, jiraIssueData);
+        } catch (editError) {
+          const isAssigneeError =
+            editError.response?.status === 400 &&
+            editError.response?.data?.errors?.assignee;
+
+          if (isAssigneeError && jiraIssueData.fields.assignee) {
+            console.log(
+              `  ⚠ Assignee ${jiraIssueData.fields.assignee.accountId} cannot be assigned in Jira. Retrying without assignee...`
+            );
+            delete jiraIssueData.fields.assignee;
+            const assigneeIdx = changes.indexOf('assignee');
+            if (assigneeIdx > -1) changes.splice(assigneeIdx, 1);
+
+            if (changes.length > 0) {
+              await editJiraIssue(jiraIssue.key, jiraIssueData);
+            }
+          } else {
+            throw editError;
+          }
+        }
         syncSummary.githubToJira = true;
         console.log(
           `  ✓ Synced from GitHub → Jira: ${changes.join(', ')} (GitHub updated ${githubIssue.updatedAt || 'unknown'})`

--- a/tests/sync-edge-cases.test.mjs
+++ b/tests/sync-edge-cases.test.mjs
@@ -704,6 +704,35 @@ console.log('\n=== Unassignable Jira user: assignee retry logic ===');
     'editJiraIssue error handling occurs before transition logic (transition is still reachable)');
 }
 
+{
+  // When assignee is the ONLY change, retry should be skipped and no false success logged
+  const changes = ['assignee'];
+  const assigneeIdx = changes.indexOf('assignee');
+  if (assigneeIdx > -1) changes.splice(assigneeIdx, 1);
+  assertEqual(changes.length, 0, 'changes is empty when assignee was the only change — retry skipped');
+}
+
+{
+  // When assignee + other fields changed, retry should proceed with remaining changes
+  const changes = ['title', 'assignee', 'description'];
+  const assigneeIdx = changes.indexOf('assignee');
+  if (assigneeIdx > -1) changes.splice(assigneeIdx, 1);
+  assertEqual(changes.length, 2, 'two changes remain after removing assignee');
+  assert(!changes.includes('assignee'), 'assignee removed from changes list');
+  assert(changes.includes('title') && changes.includes('description'), 'title and description preserved in changes');
+}
+
+{
+  // Verify success logging is gated on changes.length > 0 after the catch block
+  // This prevents false success when assignee was the only change
+  const updateSrc = readFileSync(join(__dirname, '../src/updateJiraIssue.js'), 'utf-8');
+
+  const catchBlockEnd = updateSrc.indexOf('throw editError');
+  const successGuard = updateSrc.indexOf('if (changes.length > 0) {\n          syncSummary.githubToJira', catchBlockEnd);
+  assert(successGuard > catchBlockEnd,
+    'syncSummary.githubToJira is gated on changes.length > 0 after catch block');
+}
+
 // ─── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);

--- a/tests/sync-edge-cases.test.mjs
+++ b/tests/sync-edge-cases.test.mjs
@@ -623,6 +623,87 @@ console.log('\n=== Old Jira issues without Upstream URL get GitHub issues create
   assertEqual(pf101.fields.summary, 'Issue 101', 'deduplication: manual version of PF-101 takes priority');
 }
 
+// ─── Unassignable Jira user: assignee retry logic ───────────────────────────
+
+console.log('\n=== Unassignable Jira user: assignee retry logic ===');
+
+{
+  // Verify updateJiraIssue.js wraps editJiraIssue in a try-catch that handles assignee errors
+  const updateSrc = readFileSync(join(__dirname, '../src/updateJiraIssue.js'), 'utf-8');
+
+  assert(updateSrc.includes("editError.response?.data?.errors?.assignee"),
+    'editJiraIssue catch checks for assignee field error');
+  assert(updateSrc.includes("delete jiraIssueData.fields.assignee"),
+    'assignee is removed from payload on retry');
+  assert(updateSrc.includes("Retrying without assignee"),
+    'logs a warning about unassignable user before retrying');
+}
+
+{
+  // Verify assignee error detection logic correctly identifies assignee 400 errors
+  const mockErrorResponse = {
+    status: 400,
+    data: {
+      errorMessages: [],
+      errors: { assignee: "User '557058:a502f956-47d6-4de9-85b0-75424d4014d0' cannot be assigned issues." }
+    }
+  };
+
+  const isAssigneeError =
+    mockErrorResponse.status === 400 &&
+    mockErrorResponse.data?.errors?.assignee;
+
+  assert(isAssigneeError, 'detects assignee error from Jira 400 response');
+}
+
+{
+  // Non-assignee 400 error should NOT match
+  const mockOtherError = {
+    status: 400,
+    data: {
+      errorMessages: ['Field "summary" is required'],
+      errors: { summary: 'You must specify a summary of the issue.' }
+    }
+  };
+
+  const isAssigneeError =
+    mockOtherError.status === 400 &&
+    mockOtherError.data?.errors?.assignee;
+
+  assert(!isAssigneeError, 'non-assignee 400 error is NOT treated as assignee error');
+}
+
+{
+  // Verify retry removes assignee from payload but preserves other fields
+  const payload = {
+    fields: {
+      summary: 'Test issue',
+      description: { type: 'doc', content: [] },
+      assignee: { accountId: '557058:a502f956-47d6-4de9-85b0-75424d4014d0' },
+    }
+  };
+
+  delete payload.fields.assignee;
+  assertEqual(payload.fields.assignee, undefined, 'assignee removed from payload for retry');
+  assertEqual(payload.fields.summary, 'Test issue', 'summary preserved after assignee removal');
+  assertEqual(payload.fields.description.type, 'doc', 'description preserved after assignee removal');
+}
+
+{
+  // Verify transition logic (transitionJiraIssue) is still reachable after editJiraIssue error handling
+  // The editJiraIssue try-catch should be INSIDE the changes.length block,
+  // and transitionJiraIssue should be OUTSIDE it (later in the same else branch)
+  const updateSrc = readFileSync(join(__dirname, '../src/updateJiraIssue.js'), 'utf-8');
+
+  const editTryCatchIdx = updateSrc.indexOf("} catch (editError) {");
+  const transitionIdx = updateSrc.indexOf("transitionJiraIssue(jiraIssue.key, 'Closed')");
+
+  assert(editTryCatchIdx > -1, 'editJiraIssue has inner try-catch');
+  assert(transitionIdx > -1, 'transitionJiraIssue Closed call exists');
+  assert(editTryCatchIdx < transitionIdx,
+    'editJiraIssue error handling occurs before transition logic (transition is still reachable)');
+}
+
 // ─── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);


### PR DESCRIPTION
closes #40 

## Summary
- When a GitHub issue is closed and synced to Jira, the update could fail if the mapped assignee is no longer assignable in the Jira project (e.g. `srambach` removed from PF project). The 400 error from Jira prevented the issue from being transitioned to Closed.
- Adds an inner try-catch around `editJiraIssue()` that detects assignee-specific 400 errors, removes the assignee field from the payload, and retries — allowing the transition to Closed to proceed.
- Adds 11 tests covering error detection logic, payload cleanup, and verification that the transition remains reachable.

## Test plan
- [x] `npm test` — all 116 tests pass (62 ADF + 116 sync edge cases)
- [ ] Verify next sync run closes PF-3136 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)