### PR TITLE
chore: clarify child issue skip-close log message

### DIFF
--- a/src/updateJiraIssue.js
+++ b/src/updateJiraIssue.js
@@ -165,9 +165,8 @@ export async function updateChildIssues(parentJiraKey, githubIssue, isEpic) {
               );
             } else {
               console.log(
-                ` - Skipping close of child issue ${item.child.key}: GitHub issue is still open (not a sub-issue of parent)`
+                ` - Skipping close of child issue ${item.child.key}: linked GitHub issue is still open`
               );
-              syncStats.track('warnings', { key: item.child.key, message: 'GitHub issue is still open (not a sub-issue of parent)' });
             }
           }
         }

--- a/tests/sync-edge-cases.test.mjs
+++ b/tests/sync-edge-cases.test.mjs
@@ -733,6 +733,24 @@ console.log('\n=== Unassignable Jira user: assignee retry logic ===');
     'syncSummary.githubToJira is gated on changes.length > 0 after catch block');
 }
 
+// ─── Child issue skip-close log message ─────────────────────────────────────
+
+console.log('\n=== Child issue skip-close log message ===');
+
+{
+  const updateSrc = readFileSync(join(__dirname, '../src/updateJiraIssue.js'), 'utf-8');
+
+  assert(updateSrc.includes('linked GitHub issue is still open'),
+    'skip-close log message says "linked GitHub issue is still open"');
+  assert(!updateSrc.includes('not a sub-issue of parent'),
+    'old misleading "not a sub-issue of parent" message is removed');
+  assert(!updateSrc.includes("track('warnings'") || !updateSrc.substring(
+    updateSrc.indexOf('linked GitHub issue is still open') - 200,
+    updateSrc.indexOf('linked GitHub issue is still open') + 200
+  ).includes("track('warnings'"),
+    'skip-close does not track a warning for open GitHub issues');
+}
+
 // ─── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);


### PR DESCRIPTION
Closes #41 

## Summary
- Remove misleading "(not a sub-issue of parent)" parenthetical from skip-close log message — Jira/GitHub hierarchy differences are expected, not errors
- Remove unnecessary warning tracking for open GitHub issues (normal condition, not a warning)
- Add tests verifying updated message, removal of old message, and no warning tracking

## Test plan
- [x] `npm test` passes (124/124)
- [ ] Run sync and verify skip-close logs show "linked GitHub issue is still open" without the old parenthetical

🤖 Generated with [Claude Code](https://claude.com/claude-code)