### PR TITLE
fix: add strikethrough support to markdown-ADF conversion

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1162,26 +1162,30 @@ export function adfToMarkdown(adf, options = {}) {
 // Parse inline Markdown text into ADF inline content nodes
 function parseMarkdownInline(text) {
   const nodes = [];
-  const pattern = /(\*\*(.+?)\*\*)|(\*(.+?)\*)|(_(.+?)_)|(`(.+?)`)|(!\[([^\]]*)\]\(([^)]+)\))|(\[([^\]]+)\]\(([^)]+)\))/g;
+  const pattern = /(~~(.+?)~~)|(~([^~]+?)~)|(\*\*(.+?)\*\*)|(\*(.+?)\*)|(_(.+?)_)|(`(.+?)`)|(!\[([^\]]*)\]\(([^)]+)\))|(\[([^\]]+)\]\(([^)]+)\))/g;
   let lastIndex = 0;
   let match;
   while ((match = pattern.exec(text)) !== null) {
     if (match.index > lastIndex) {
       nodes.push({ type: 'text', text: text.slice(lastIndex, match.index) });
     }
-    if (match[1]) { // **bold**
-      nodes.push({ type: 'text', text: match[2], marks: [{ type: 'strong' }] });
-    } else if (match[3]) { // *italic*
-      nodes.push({ type: 'text', text: match[4], marks: [{ type: 'em' }] });
-    } else if (match[5]) { // _italic_
-      nodes.push({ type: 'text', text: match[6], marks: [{ type: 'em' }] });
-    } else if (match[7]) { // `code`
-      nodes.push({ type: 'text', text: match[8], marks: [{ type: 'code' }] });
-    } else if (match[9]) { // ![alt](url) — inline image as linked text
-      const alt = match[10] || 'image';
-      nodes.push({ type: 'text', text: alt, marks: [{ type: 'link', attrs: { href: match[11] } }] });
-    } else if (match[12]) { // [text](url)
-      nodes.push({ type: 'text', text: match[13], marks: [{ type: 'link', attrs: { href: match[14] } }] });
+    if (match[1]) { // ~~strikethrough~~
+      nodes.push({ type: 'text', text: match[2], marks: [{ type: 'strike' }] });
+    } else if (match[3]) { // ~strikethrough~
+      nodes.push({ type: 'text', text: match[4], marks: [{ type: 'strike' }] });
+    } else if (match[5]) { // **bold**
+      nodes.push({ type: 'text', text: match[6], marks: [{ type: 'strong' }] });
+    } else if (match[7]) { // *italic*
+      nodes.push({ type: 'text', text: match[8], marks: [{ type: 'em' }] });
+    } else if (match[9]) { // _italic_
+      nodes.push({ type: 'text', text: match[10], marks: [{ type: 'em' }] });
+    } else if (match[11]) { // `code`
+      nodes.push({ type: 'text', text: match[12], marks: [{ type: 'code' }] });
+    } else if (match[13]) { // ![alt](url) — inline image as linked text
+      const alt = match[14] || 'image';
+      nodes.push({ type: 'text', text: alt, marks: [{ type: 'link', attrs: { href: match[15] } }] });
+    } else if (match[16]) { // [text](url)
+      nodes.push({ type: 'text', text: match[17], marks: [{ type: 'link', attrs: { href: match[18] } }] });
     }
     lastIndex = pattern.lastIndex;
   }

--- a/tests/adf-conversion.test.mjs
+++ b/tests/adf-conversion.test.mjs
@@ -291,6 +291,113 @@ buildRunner(`
   this.assert(allText.includes('Quoted text'), 'content preserved');
 `).call({ assert, randomUUID });
 
+// ─── Strikethrough: Markdown → ADF ───────────────────────────────────────────
+
+console.log('\n=== Strikethrough: Markdown → ADF ===');
+
+buildRunner(`
+  const md = '~~deleted text~~';
+  const blocks = markdownToADFBlocks(md);
+  const para = blocks[0];
+
+  this.assert(para.type === 'paragraph', 'block is paragraph');
+  this.assert(para.content.length === 1, 'has 1 inline node');
+  this.assert(para.content[0].text === 'deleted text', 'text content correct');
+  this.assert(para.content[0].marks.length === 1, 'has 1 mark');
+  this.assert(para.content[0].marks[0].type === 'strike', 'mark type is strike');
+`).call({ assert, randomUUID });
+
+// ─── Strikethrough: ADF → Markdown ───────────────────────────────────────────
+
+console.log('\n=== Strikethrough: ADF → Markdown ===');
+
+buildRunner(`
+  const adf = [{
+    type: 'paragraph',
+    content: [{ type: 'text', text: 'deleted text', marks: [{ type: 'strike' }] }]
+  }];
+  const md = adfBlocksToMarkdown(adf);
+
+  this.assert(md === '~~deleted text~~', 'ADF strike converts to ~~text~~: ' + JSON.stringify(md));
+`).call({ assert, randomUUID });
+
+// ─── Strikethrough: inline within sentence ───────────────────────────────────
+
+console.log('\n=== Strikethrough: inline within sentence ===');
+
+buildRunner(`
+  const md = 'This has ~~removed~~ text in it';
+  const blocks = markdownToADFBlocks(md);
+  const content = blocks[0].content;
+
+  this.assert(content.length === 3, 'has 3 inline nodes');
+  this.assert(content[0].text === 'This has ', 'prefix text correct');
+  this.assert(content[1].text === 'removed', 'strike text correct');
+  this.assert(content[1].marks[0].type === 'strike', 'strike mark present');
+  this.assert(content[2].text === ' text in it', 'suffix text correct');
+`).call({ assert, randomUUID });
+
+// ─── Strikethrough: single tilde ~text~ ─────────────────────────────────────
+
+console.log('\n=== Strikethrough: single tilde ~text~ ===');
+
+buildRunner(`
+  const md = '~deleted text~';
+  const blocks = markdownToADFBlocks(md);
+  const para = blocks[0];
+
+  this.assert(para.content.length === 1, 'has 1 inline node');
+  this.assert(para.content[0].text === 'deleted text', 'text content correct');
+  this.assert(para.content[0].marks[0].type === 'strike', 'single tilde mark is strike');
+`).call({ assert, randomUUID });
+
+// ─── Strikethrough: single tilde inline ─────────────────────────────────────
+
+console.log('\n=== Strikethrough: single tilde inline ===');
+
+buildRunner(`
+  const md = 'item 4. ~things~';
+  const blocks = markdownToADFBlocks(md);
+  const content = blocks[0].content;
+
+  this.assert(content.length === 2, 'has 2 inline nodes');
+  this.assert(content[0].text === 'item 4. ', 'prefix text correct');
+  this.assert(content[1].text === 'things', 'strike text correct');
+  this.assert(content[1].marks[0].type === 'strike', 'single tilde strike mark present');
+`).call({ assert, randomUUID });
+
+// ─── Strikethrough: double tilde preferred over single ──────────────────────
+
+console.log('\n=== Strikethrough: double tilde matched before single ===');
+
+buildRunner(`
+  const md = '~~double~~ and ~single~';
+  const blocks = markdownToADFBlocks(md);
+  const content = blocks[0].content;
+
+  this.assert(content.length === 3, 'has 3 inline nodes');
+  this.assert(content[0].text === 'double', 'double tilde text correct');
+  this.assert(content[0].marks[0].type === 'strike', 'double tilde is strike');
+  this.assert(content[2].text === 'single', 'single tilde text correct');
+  this.assert(content[2].marks[0].type === 'strike', 'single tilde is strike');
+`).call({ assert, randomUUID });
+
+// ─── Strikethrough: mixed with other formatting ─────────────────────────────
+
+console.log('\n=== Strikethrough: mixed with other formatting ===');
+
+buildRunner(`
+  const md = '**bold** and ~~struck~~ and *italic*';
+  const blocks = markdownToADFBlocks(md);
+  const content = blocks[0].content;
+
+  this.assert(content.length === 5, 'has 5 inline nodes');
+  this.assert(content[0].marks[0].type === 'strong', 'first is bold');
+  this.assert(content[2].marks[0].type === 'strike', 'third is strikethrough');
+  this.assert(content[2].text === 'struck', 'strike text correct');
+  this.assert(content[4].marks[0].type === 'em', 'fifth is italic');
+`).call({ assert, randomUUID });
+
 // ─── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);


### PR DESCRIPTION
Closes #44 

## Summary
- Add `~~double tilde~~` and `~single tilde~` strikethrough parsing in `parseMarkdownInline`, converting to ADF `strike` marks
- Double tilde matched before single tilde to handle both syntaxes correctly
- Add 7 test cases covering: basic conversion both directions, inline usage, single vs double tilde, mixed formatting

## Test plan
- [x] `npm test` passes all existing + new strikethrough tests
- [x] Verify strikethrough text in GitHub issues syncs to Jira with strike formatting
- [x] Verify Jira strike marks convert back to `~~text~~` in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)