### PR TITLE
feat: sync GitHub PR links to Jira Git Pull Request field

### DIFF
--- a/src/createJiraIssue.js
+++ b/src/createJiraIssue.js
@@ -5,6 +5,7 @@ import {
   createNewJiraIssue,
   syncCommentsToJira,
   buildDescriptionADF,
+  buildPrUrlsADF,
 } from './helpers.js';
 import { updateChildIssues } from './updateJiraIssue.js';
 import { addJiraLinkToGitHub } from './syncJiraToGitHub.js';
@@ -25,6 +26,9 @@ export async function createChildIssues(
     const assignees = subIssue?.assignees?.nodes
       ?.map((a) => a.login)
       .join(', ');
+    const subIssuePrUrls = subIssue.closedByPullRequestsReferences?.nodes
+      ?.map((pr) => pr.url)
+      .filter(Boolean) || [];
     const childIssue = {
       fields: {
         project: {
@@ -37,6 +41,7 @@ export async function createChildIssues(
           reporter: subIssue?.author?.login || '',
           assignees,
         }),
+        ...(subIssuePrUrls.length > 0 && { 'customfield_10875': buildPrUrlsADF(subIssuePrUrls) }),
       },
     };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -797,6 +797,80 @@ const FETCH_SUB_ISSUES = `
   }
 `;
 
+// Fetch recently-updated PRs and the issues they close (for PR link sync)
+const GET_RECENT_PRS = `
+  query GetRecentPRs($owner: String!, $repo: String!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequests(
+        first: 50
+        after: $cursor
+        orderBy: {field: UPDATED_AT, direction: DESC}
+        states: [OPEN, MERGED]
+      ) {
+        nodes {
+          url
+          updatedAt
+          closingIssuesReferences(first: 10) {
+            nodes {
+              url
+            }
+          }
+        }
+        pageInfo { endCursor hasNextPage }
+      }
+    }
+  }
+`;
+
+// Lightweight query to get all PR links for a specific issue
+const GET_ISSUE_PR_LINKS = `
+  query GetIssuePRLinks($owner: String!, $repo: String!, $issueNumber: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $issueNumber) {
+        closedByPullRequestsReferences(first: 10) {
+          nodes { url }
+        }
+      }
+    }
+  }
+`;
+
+// Returns unique GitHub issue URLs from PRs updated since `since` for a repo
+export async function getRepoPRsSince(owner, repo, since) {
+  const sinceDate = new Date(since);
+  const issueUrls = new Set();
+  let cursor = null;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const response = await executeGraphQLQuery(GET_RECENT_PRS, { owner, repo, cursor }, owner);
+    const prs = response?.repository?.pullRequests;
+    if (!prs) break;
+
+    let hitOldPR = false;
+    for (const pr of prs.nodes) {
+      if (new Date(pr.updatedAt) < sinceDate) {
+        hitOldPR = true;
+        break;
+      }
+      for (const issue of pr.closingIssuesReferences.nodes) {
+        issueUrls.add(issue.url);
+      }
+    }
+
+    hasNextPage = !hitOldPR && prs.pageInfo.hasNextPage;
+    cursor = prs.pageInfo.endCursor;
+  }
+
+  return [...issueUrls];
+}
+
+// Returns all PR URLs that close a specific GitHub issue
+export async function getIssuePRLinks(owner, repo, issueNumber) {
+  const response = await executeGraphQLQuery(GET_ISSUE_PR_LINKS, { owner, repo, issueNumber }, owner);
+  return response?.repository?.issue?.closedByPullRequestsReferences?.nodes?.map((pr) => pr.url) || [];
+}
+
 // Fetch remaining sub-issues for issues where the initial bulk query was truncated
 async function fetchRemainingSubIssues(issue, owner, repo) {
   const { subIssues } = issue;
@@ -942,6 +1016,7 @@ export function extractTextFromADF(adf) {
   if (!adf) return '';
   if (typeof adf === 'string') return adf;
   if (adf.type === 'hardBreak') return '\n';
+  if (adf.type === 'inlineCard') return adf.attrs?.url || '';
   if (adf.type === 'text') return adf.text || '';
   if (adf.content) {
     return adf.content.map(extractTextFromADF).join('');
@@ -1524,7 +1599,7 @@ function buildCommentADF(comment, { truncated = false } = {}) {
 export function buildPrUrlsADF(urls) {
   const content = [];
   urls.forEach((url, i) => {
-    content.push({ type: 'text', text: String(url) });
+    content.push({ type: 'inlineCard', attrs: { url: String(url) } });
     if (i < urls.length - 1) {
       content.push({ type: 'hardBreak' });
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -391,6 +391,7 @@ export const buildJiraIssueData = (githubIssue, isUpdateIssue = false) => {
     assignees,
     issueType,
     author,
+    closedByPullRequestsReferences,
   } = githubIssue;
 
   // Extract repository name from the repository object
@@ -454,6 +455,13 @@ export const buildJiraIssueData = (githubIssue, isUpdateIssue = false) => {
     if (jiraIssueType.jiraName === 'Epic') {
       jiraIssue.fields['customfield_10011'] = title;
     }
+  }
+
+  const prUrls = closedByPullRequestsReferences?.nodes
+    ?.map((pr) => pr.url)
+    .filter(Boolean) || [];
+  if (prUrls.length > 0) {
+    jiraIssue.fields['customfield_10875'] = buildPrUrlsADF(prUrls);
   }
 
   return jiraIssue;
@@ -585,6 +593,11 @@ export const GET_ALL_REPO_ISSUES = `
           parent {
             url
           }
+          closedByPullRequestsReferences(first: 5) {
+            nodes {
+              url
+            }
+          }
           subIssues(first: $numSubIssuesPerIssue) {
             nodes {
               title
@@ -619,6 +632,11 @@ export const GET_ALL_REPO_ISSUES = `
                   url
                 }
                 totalCount
+              }
+              closedByPullRequestsReferences(first: 5) {
+                nodes {
+                  url
+                }
               }
             }
             pageInfo {
@@ -687,6 +705,11 @@ export const GET_ISSUE_DETAILS = `
         parent {
           url
         }
+        closedByPullRequestsReferences(first: 5) {
+          nodes {
+            url
+          }
+        }
         subIssues(first: 50) {
           nodes {
             state
@@ -721,6 +744,11 @@ export const GET_ISSUE_DETAILS = `
               }
               totalCount
             }
+            closedByPullRequestsReferences(first: 5) {
+              nodes {
+                url
+              }
+            }
           }
           totalCount
         }
@@ -754,6 +782,11 @@ const FETCH_SUB_ISSUES = `
                 url
               }
               totalCount
+            }
+            closedByPullRequestsReferences(first: 5) {
+              nodes {
+                url
+              }
             }
           }
           pageInfo { endCursor hasNextPage }
@@ -1484,6 +1517,19 @@ function buildCommentADF(comment, { truncated = false } = {}) {
       },
     ],
   };
+}
+
+// Build ADF for the Git Pull Request textarea field (customfield_10875)
+// URLs separated by hardBreaks within a single paragraph
+export function buildPrUrlsADF(urls) {
+  const content = [];
+  urls.forEach((url, i) => {
+    content.push({ type: 'text', text: String(url) });
+    if (i < urls.length - 1) {
+      content.push({ type: 'hardBreak' });
+    }
+  });
+  return { type: 'doc', version: 1, content: [{ type: 'paragraph', content }] };
 }
 
 // Build the metadata footer paragraph as ADF nodes

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ const fetchJiraIssues = async (owner, repo, since) => {
   const jiraDate = new Date(since).toISOString().replace('T', ' ').substring(0, 16);
   const jiraIssues = await paginatedJiraSearch(
     `project = PF AND component = "${repo}" AND status not in (Closed, Resolved) AND updatedDate >= "${jiraDate}" ORDER BY key ASC`,
-    'key,id,description,status,resolution,assignee,issuetype,updated,summary,components,reporter'
+    'key,id,description,status,resolution,assignee,issuetype,updated,summary,components,reporter,customfield_10875'
   );
   console.log(`    --> Found ${jiraIssues.length} open Jira issues updated since ${since} for Jira component ${ repo }`);
   return jiraIssues;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import {
   checkAndHandleArchivedJiraIssue,
   syncUpdatedJiraIssuesToGitHub,
 } from './syncJiraToGitHub.js';
+import { syncPRLinksToJira } from './syncPRLinksToJira.js';
 import { errorCollector, syncStats } from './logging.js';
 
 export let jiraIssues = [];
@@ -197,6 +198,12 @@ async function syncIssues(owner, repo, since, direction = 'both') {
       // if (unprocessedJiraIssues.length > 0) {
         // await handleUnprocessedJiraIssues(unprocessedJiraIssues, repo);
       // }
+    }
+
+    // Sync PR links for issues not updated recently (PRs don't bump issue.updatedAt)
+    if (direction === 'github-to-jira' || direction === 'both') {
+      console.log(`\n= GitHub → Jira sync: PR links from recently-updated PRs =\n`);
+      await syncPRLinksToJira(owner, repo, since);
     }
 
     // Jira → GitHub sync

--- a/src/syncPRLinksToJira.js
+++ b/src/syncPRLinksToJira.js
@@ -1,0 +1,41 @@
+import { getRepoPRsSince, getIssuePRLinks, editJiraIssue, buildPrUrlsADF, delay } from './helpers.js';
+import { findJiraIssue } from './findJiraIssue.js';
+import { errorCollector, syncStats } from './logging.js';
+
+function parseIssueUrl(url) {
+  const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], issueNumber: parseInt(match[3], 10) };
+}
+
+// Sync PR links to Jira for issues referenced by recently-updated PRs.
+// Runs in addition to the main issue sync to catch cases where GitHub issues
+// are not marked as updated when a PR is linked.
+export async function syncPRLinksToJira(owner, repo, since) {
+  try {
+    const issueUrls = await getRepoPRsSince(owner, repo, since);
+    if (issueUrls.length === 0) return;
+
+    console.log(` - Found ${issueUrls.length} GitHub issue${issueUrls.length === 1 ? '' : 's'} with recently-updated PR links`);
+
+    for (const issueUrl of issueUrls) {
+      const parsed = parseIssueUrl(issueUrl);
+      if (!parsed) continue;
+
+      const prUrls = await getIssuePRLinks(parsed.owner, parsed.repo, parsed.issueNumber);
+      if (prUrls.length === 0) continue;
+
+      const jiraIssue = await findJiraIssue(issueUrl);
+      if (!jiraIssue) continue;
+
+      await delay();
+      await editJiraIssue(jiraIssue.key, {
+        fields: { customfield_10875: buildPrUrlsADF(prUrls) },
+      });
+      console.log(` - Updated PR link${prUrls.length === 1 ? '' : 's'} on ${jiraIssue.key}: ${prUrls.join(', ')}`);
+      syncStats.track('jiraUpdated');
+    }
+  } catch (error) {
+    errorCollector.addError(`SYNCPRLINKSTOJIRA: Error syncing PR links for ${owner}/${repo}`, error);
+  }
+}

--- a/src/updateJiraIssue.js
+++ b/src/updateJiraIssue.js
@@ -272,10 +272,21 @@ export async function updateJiraIssue(jiraIssue, githubIssue) {
       const hadGitHubAssignee = githubIssue.assignees?.nodes?.length > 0;
       const assigneeChanged = !hadAssignee && hadGitHubAssignee;
 
+      const newPrUrls = githubIssue.closedByPullRequestsReferences?.nodes
+        ?.map((pr) => pr.url)
+        .filter(Boolean) || [];
+      const currentPrField = extractTextFromADF(jiraIssue.fields.customfield_10875).trim();
+      const newPrField = newPrUrls.join('\n');
+      const prLinksChanged = currentPrField !== newPrField;
+      if (!prLinksChanged) {
+        delete jiraIssueData.fields['customfield_10875'];
+      }
+
       const changes = [];
       if (titleChanged) changes.push('title');
       if (descriptionChanged) changes.push('description');
       if (assigneeChanged) changes.push('assignee');
+      if (prLinksChanged) changes.push('prLinks');
 
       if (changes.length > 0) {
         try {

--- a/tests/sync-edge-cases.test.mjs
+++ b/tests/sync-edge-cases.test.mjs
@@ -13,7 +13,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Import exported functions directly
 import { parseGitHubUrl, buildBatchedIssueStateQuery } from '../src/syncJiraToGitHub.js';
-import { extractTextFromADF, extractUpstreamUrl, buildJiraIssueData, paginatedJiraSearch } from '../src/helpers.js';
+import { extractTextFromADF, extractUpstreamUrl, buildJiraIssueData, paginatedJiraSearch, buildPrUrlsADF } from '../src/helpers.js';
 import { syncStats, errorCollector } from '../src/logging.js';
 
 let passed = 0;
@@ -749,6 +749,87 @@ console.log('\n=== Child issue skip-close log message ===');
     updateSrc.indexOf('linked GitHub issue is still open') + 200
   ).includes("track('warnings'"),
     'skip-close does not track a warning for open GitHub issues');
+}
+
+// ─── PR link sync (customfield_10875) ───────────────────────────────────────
+
+console.log('\n=== PR link sync (customfield_10875) ===');
+
+const baseIssue = {
+  title: 'Test issue',
+  url: 'https://github.com/patternfly/patternfly-react/issues/100',
+  body: 'Test body',
+  number: 100,
+  labels: { nodes: [] },
+  assignees: { nodes: [] },
+  author: { login: 'testuser' },
+  issueType: null,
+};
+
+{
+  // With PRs — field is ADF doc with URLs as text nodes separated by hardBreaks
+  const issue = {
+    ...baseIssue,
+    closedByPullRequestsReferences: {
+      nodes: [
+        { url: 'https://github.com/patternfly/patternfly-react/pull/200' },
+        { url: 'https://github.com/patternfly/patternfly-react/pull/201' },
+      ],
+    },
+  };
+  const result = buildJiraIssueData(issue, false);
+  const field = result.fields['customfield_10875'];
+  assertEqual(field?.type, 'doc', 'customfield_10875 is ADF doc');
+  const text = extractTextFromADF(field).trim();
+  assert(text.includes('pull/200'), 'ADF contains first PR URL');
+  assert(text.includes('pull/201'), 'ADF contains second PR URL');
+}
+
+{
+  // No PRs — field not set
+  const issue = {
+    ...baseIssue,
+    closedByPullRequestsReferences: { nodes: [] },
+  };
+  const result = buildJiraIssueData(issue, false);
+  assert(!('customfield_10875' in result.fields), 'customfield_10875 not set when no PRs');
+}
+
+{
+  // Missing closedByPullRequestsReferences — no crash, field not set
+  const result = buildJiraIssueData(baseIssue, false);
+  assert(!('customfield_10875' in result.fields), 'customfield_10875 not set when field missing from response');
+}
+
+{
+  // Single PR — ADF with single text node, no hardBreak
+  const issue = {
+    ...baseIssue,
+    closedByPullRequestsReferences: {
+      nodes: [{ url: 'https://github.com/patternfly/patternfly-react/pull/300' }],
+    },
+  };
+  const result = buildJiraIssueData(issue, false);
+  const field = result.fields['customfield_10875'];
+  assertEqual(field?.type, 'doc', 'single PR customfield_10875 is ADF doc');
+  const para = field.content[0];
+  assertEqual(para.content.length, 1, 'single PR paragraph has 1 node (no hardBreak)');
+  assertEqual(para.content[0].text, 'https://github.com/patternfly/patternfly-react/pull/300', 'single PR URL is correct');
+}
+
+{
+  // buildPrUrlsADF: hardBreak between multiple URLs
+  const adf = buildPrUrlsADF(['https://example.com/pull/1', 'https://example.com/pull/2']);
+  const para = adf.content[0];
+  assertEqual(para.content.length, 3, 'two PRs produce 3 nodes: text, hardBreak, text');
+  assertEqual(para.content[1].type, 'hardBreak', 'middle node is hardBreak');
+}
+
+{
+  // GraphQL queries include closedByPullRequestsReferences
+  const helpersSrc = readFileSync(join(__dirname, '../src/helpers.js'), 'utf-8');
+  const occurrences = (helpersSrc.match(/closedByPullRequestsReferences/g) || []).length;
+  assert(occurrences >= 4, `closedByPullRequestsReferences appears in at least 4 query locations (found ${occurrences})`);
 }
 
 // ─── Summary ────────────────────────────────────────────────────────────────

--- a/tests/sync-edge-cases.test.mjs
+++ b/tests/sync-edge-cases.test.mjs
@@ -802,7 +802,7 @@ const baseIssue = {
 }
 
 {
-  // Single PR — ADF with single text node, no hardBreak
+  // Single PR — ADF with single inlineCard node, no hardBreak
   const issue = {
     ...baseIssue,
     closedByPullRequestsReferences: {
@@ -814,15 +814,43 @@ const baseIssue = {
   assertEqual(field?.type, 'doc', 'single PR customfield_10875 is ADF doc');
   const para = field.content[0];
   assertEqual(para.content.length, 1, 'single PR paragraph has 1 node (no hardBreak)');
-  assertEqual(para.content[0].text, 'https://github.com/patternfly/patternfly-react/pull/300', 'single PR URL is correct');
+  assertEqual(para.content[0].type, 'inlineCard', 'single PR node is inlineCard');
+  assertEqual(para.content[0].attrs.url, 'https://github.com/patternfly/patternfly-react/pull/300', 'single PR inlineCard url is correct');
 }
 
 {
-  // buildPrUrlsADF: hardBreak between multiple URLs
+  // buildPrUrlsADF: inlineCard nodes with hardBreak between them
   const adf = buildPrUrlsADF(['https://example.com/pull/1', 'https://example.com/pull/2']);
   const para = adf.content[0];
-  assertEqual(para.content.length, 3, 'two PRs produce 3 nodes: text, hardBreak, text');
+  assertEqual(para.content.length, 3, 'two PRs produce 3 nodes: inlineCard, hardBreak, inlineCard');
+  assertEqual(para.content[0].type, 'inlineCard', 'first node is inlineCard');
+  assertEqual(para.content[0].attrs.url, 'https://example.com/pull/1', 'first inlineCard url correct');
   assertEqual(para.content[1].type, 'hardBreak', 'middle node is hardBreak');
+  assertEqual(para.content[2].type, 'inlineCard', 'last node is inlineCard');
+}
+
+{
+  // extractTextFromADF handles inlineCard nodes — returns the url attr
+  const adf = {
+    type: 'doc',
+    version: 1,
+    content: [{
+      type: 'paragraph',
+      content: [
+        { type: 'inlineCard', attrs: { url: 'https://example.com/pull/1' } },
+        { type: 'hardBreak' },
+        { type: 'inlineCard', attrs: { url: 'https://example.com/pull/2' } },
+      ],
+    }],
+  };
+  const text = extractTextFromADF(adf);
+  assertEqual(text, 'https://example.com/pull/1\nhttps://example.com/pull/2', 'extractTextFromADF extracts URLs from inlineCard nodes');
+}
+
+{
+  // extractTextFromADF: inlineCard with no attrs.url returns empty string
+  const text = extractTextFromADF({ type: 'inlineCard', attrs: {} });
+  assertEqual(text, '', 'inlineCard with no url attr returns empty string');
 }
 
 {
@@ -830,6 +858,50 @@ const baseIssue = {
   const helpersSrc = readFileSync(join(__dirname, '../src/helpers.js'), 'utf-8');
   const occurrences = (helpersSrc.match(/closedByPullRequestsReferences/g) || []).length;
   assert(occurrences >= 4, `closedByPullRequestsReferences appears in at least 4 query locations (found ${occurrences})`);
+}
+
+// ─── PR link sync via recently-updated PRs ───────────────────────────────────
+
+console.log('\n=== PR link sync via recently-updated PRs ===');
+
+{
+  // helpers.js exports getRepoPRsSince and getIssuePRLinks
+  const helpersSrc = readFileSync(join(__dirname, '../src/helpers.js'), 'utf-8');
+  assert(helpersSrc.includes('export async function getRepoPRsSince'), 'getRepoPRsSince is exported');
+  assert(helpersSrc.includes('export async function getIssuePRLinks'), 'getIssuePRLinks is exported');
+  assert(helpersSrc.includes('GET_RECENT_PRS'), 'GET_RECENT_PRS query defined');
+  assert(helpersSrc.includes('closingIssuesReferences'), 'GET_RECENT_PRS fetches closingIssuesReferences');
+  assert(helpersSrc.includes('GET_ISSUE_PR_LINKS'), 'GET_ISSUE_PR_LINKS query defined');
+}
+
+{
+  // getRepoPRsSince stops paginating when it hits a PR older than since
+  const helpersSrc = readFileSync(join(__dirname, '../src/helpers.js'), 'utf-8');
+  assert(helpersSrc.includes('new Date(pr.updatedAt) < sinceDate'), 'getRepoPRsSince stops at PRs older than since');
+}
+
+{
+  // syncPRLinksToJira.js exists and has expected structure
+  const syncSrc = readFileSync(join(__dirname, '../src/syncPRLinksToJira.js'), 'utf-8');
+  assert(syncSrc.includes('export async function syncPRLinksToJira'), 'syncPRLinksToJira is exported');
+  assert(syncSrc.includes('getRepoPRsSince'), 'calls getRepoPRsSince');
+  assert(syncSrc.includes('getIssuePRLinks'), 'calls getIssuePRLinks');
+  assert(syncSrc.includes('findJiraIssue'), 'calls findJiraIssue');
+  assert(syncSrc.includes('editJiraIssue'), 'calls editJiraIssue');
+  assert(syncSrc.includes('buildPrUrlsADF'), 'uses buildPrUrlsADF for ADF format');
+}
+
+{
+  // index.js imports and calls syncPRLinksToJira
+  const indexSrc = readFileSync(join(__dirname, '../src/index.js'), 'utf-8');
+  assert(indexSrc.includes("import { syncPRLinksToJira }"), 'index.js imports syncPRLinksToJira');
+  assert(indexSrc.includes('await syncPRLinksToJira(owner, repo, since)'), 'index.js calls syncPRLinksToJira');
+}
+
+{
+  // parseIssueUrl correctly parses GitHub issue URLs (inline function in syncPRLinksToJira)
+  const syncSrc = readFileSync(join(__dirname, '../src/syncPRLinksToJira.js'), 'utf-8');
+  assert(syncSrc.includes('issueNumber: parseInt'), 'parseIssueUrl extracts issue number as integer');
 }
 
 // ─── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fetches `closedByPullRequestsReferences` from GitHub GraphQL for all issues and sub-issues
- Populates Jira custom field `customfield_10875` ("Git Pull Request") as ADF with PR URLs, one per line
- Skips unnecessary Jira writes when PR links haven't changed since last sync
- Covers both create and update paths, including child issues

Closes #47

Screenshot of what implementation looks like, using this PR to update the [Jira for the original Github](https://redhat.atlassian.net/browse/PF-4292) issue #47:
<img width="964" height="349" alt="Screenshot 2026-07-09 at 10 12 41 AM" src="https://github.com/user-attachments/assets/9dba418c-5264-4346-aaab-e75e1033ea81" />


## Test plan

- [x] `npm test` passes (135 tests)
- [x] Run sync against a repo with issues that have linked PRs — verify `customfield_10875` populated in Jira
- [x] Re-run sync — verify no unnecessary updates when PRs unchanged

🤖 Assisted by [Claude Code](https://claude.com/claude-code)